### PR TITLE
Fix WithContext Parsing

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -686,7 +686,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			return true
 		} else if sel, ok := call.Fun.(*ast.SelectorExpr); !ok {
 			return true
-		} else if typ := typeof(sel.X); typ == nil || typ.String() != "go.sia.tech/jape.Client" {
+		} else if typ := typeof(sel.X); typ == nil || (typ.String() != "go.sia.tech/jape.Client" && typ.String() != "*go.sia.tech/jape.Client") {
 			return true
 		} else if m := sel.Sel.Name; m != "GET" && m != "POST" && m != "PUT" && m != "DELETE" && m != "Custom" {
 			return true


### PR DESCRIPTION
I think the problem was that the client route parser is expecting a `jape.Client` but `jape.Client.WithContext` returns a `*jape.Client`.  So we can just accept `*jape.Client` in the client parser to solve the problem.

Tested with:
```
// AcquireContract acquires a contract for a given amount of time unless
// released manually before that time.
func (c *Client) AcquireContract(ctx context.Context, fcid types.FileContractID, priority int, d time.Duration) (lockID uint64, err error) {
    var resp api.ContractAcquireResponse
    err = c.c.WithContext(ctx).POST(fmt.Sprintf("/contract/%s/acquire", fcid), api.ContractAcquireRequest{
        Duration: api.Duration(d),
        Priority: priority,
    }, &resp)
    lockID = resp.LockID
    return
}
```
