### PR TITLE
Fix unhandled expression panic

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -70,6 +70,11 @@ func evalConstString(expr ast.Expr, info *types.Info) string {
 			return constant.StringVal(typ.Value)
 		}
 		return "%s"
+	case *ast.SelectorExpr:
+		if typ, ok := info.Types[v]; ok && typ.Value != nil {
+			return constant.StringVal(typ.Value)
+		}
+		return "%s"
 	default:
 		panic(fmt.Sprintf("unhandled expr type (%T)", expr))
 	}


### PR DESCRIPTION
`japecheck` currently panics when you pass a constant (imported from another package) to `DecodeForm`, the type switch in `evalConstString` is missing a case for `ast.SelectorExpr`. This code fixes it but since I'm not terrible familiar with the analyzer I'm not 100% sure whether it covers all edges