### PR TITLE
Support separate packages

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -826,7 +826,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		for _, sr := range routes {
 			if !sr.seen {
 				pass.Report(analysis.Diagnostic{
-					Message: fmt.Sprintf("Client missing method for %v", sr.normalizedRoute()),
+					Message: fmt.Sprintf("Client missing method for %v", sr),
 				})
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -57,7 +57,9 @@ func (c *Client) GET(route string, r interface{}) error { return c.req(http.Meth
 
 // POST performs a POST request. If d is non-nil, it is encoded as the request
 // body. If r is non-nil, the response is decoded into it.
-func (c *Client) POST(route string, d, r interface{}) error { return c.req(http.MethodPost, route, d, r) }
+func (c *Client) POST(route string, d, r interface{}) error {
+	return c.req(http.MethodPost, route, d, r)
+}
 
 // PUT performs a PUT request, encoding d as the request body.
 func (c *Client) PUT(route string, d interface{}) error { return c.req(http.MethodPut, route, d, nil) }
@@ -67,7 +69,9 @@ func (c *Client) DELETE(route string) error { return c.req(http.MethodDelete, ro
 
 // PATCH performs a PATCH request. If d is non-nil, it is encoded as the request
 // body. If r is non-nil, the response is decoded into it.
-func (c *Client) PATCH(route string, d, r interface{}) error { return c.req(http.MethodPatch, route, d, r) }
+func (c *Client) PATCH(route string, d, r interface{}) error {
+	return c.req(http.MethodPatch, route, d, r)
+}
 
 // Custom is a no-op that simply declares the request and response types used by
 // a client method. This allows japecheck to be used on endpoints that do not


### PR DESCRIPTION
Fixes the issue identified in https://github.com/SiaFoundation/jape/issues/13

The basic problem was that client/server definitions can be in two packages like they currently are in renterd's bus/worker.  Jape before only supported having client/server definitions each in their own file.  Now they can be in multiple files in multiple packages.  This requires storing the route information globally and in a thread-safe way because Analyzer.Run can be called concurrently when multiple packages are provided as arguments.

Also: Changes in the Github action are almost ready I just want to test them a bit.