### PR TITLE
Don't check that GET response is written if type checking is disabled

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -197,7 +197,7 @@ func parseServerRoute(kv *ast.KeyValueExpr, pass *analysis.Pass) (*serverRoute, 
 						})
 						return false
 					}
-					if r.response == types.Typ[types.UntypedNil] {
+					if checkTypes && r.response == types.Typ[types.UntypedNil] {
 						pass.Report(analysis.Diagnostic{
 							Pos:     call.Args[0].Pos(),
 							Message: fmt.Sprintf("%v routes should write a response object", r.method),
@@ -356,7 +356,7 @@ func parseServerRoute(kv *ast.KeyValueExpr, pass *analysis.Pass) (*serverRoute, 
 		r.response = types.Typ[types.UntypedNil]
 	}
 
-	if r.method == "GET" && r.response == types.Typ[types.UntypedNil] {
+	if checkTypes && r.method == "GET" && r.response == types.Typ[types.UntypedNil] {
 		pass.Report(analysis.Diagnostic{
 			Pos:     funcBody.Pos(),
 			Message: fmt.Sprintf("%v routes should write a response object", r.method),


### PR DESCRIPTION
If we disable type checking to use a custom response encoder, then the current version of jape will be confused because it won't be able to find a jc.Encode anywhere in the handler and won't recognize whatever custom encoding function is used.  This PR disables checks that a response object is written when type checking is disabled.

Issue encountered here originally: https://github.com/SiaFoundation/renterd/pull/1525