### PR TITLE
Fix parsing client routes

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -606,9 +606,14 @@ func parseClientRoute(call *ast.CallExpr, pass *analysis.Pass) *clientRoute {
 		return r
 	}
 
+	// We need call.Args[1].  Example:
+	// GET(ctx context.Context, route string, r interface{}) error
+	// call.Args[0] = context
+	// call.Args[1] = route
+	// call.Args[2] = pointer to response object
 	r := &clientRoute{
 		method: call.Fun.(*ast.SelectorExpr).Sel.Name,
-		path:   strings.TrimPrefix(evalConstString(call.Args[0], pass.TypesInfo), clientPrefix),
+		path:   strings.TrimPrefix(evalConstString(call.Args[1], pass.TypesInfo), clientPrefix),
 	}
 
 	switch r.method {

--- a/analyzer.go
+++ b/analyzer.go
@@ -618,17 +618,17 @@ func parseClientRoute(call *ast.CallExpr, pass *analysis.Pass) *clientRoute {
 
 	switch r.method {
 	case "GET":
-		r.response = call.Args[1]
+		r.response = call.Args[2]
 	case "POST":
-		r.request = call.Args[1]
-		r.response = call.Args[2]
+		r.request = call.Args[2]
+		r.response = call.Args[3]
 	case "PUT":
-		r.request = call.Args[1]
+		r.request = call.Args[2]
 	case "PATCH":
-		r.request = call.Args[1]
-		r.response = call.Args[2]
+		r.request = call.Args[2]
+		r.response = call.Args[3]
 	}
-	sprintfParse(r, call.Args[0])
+	sprintfParse(r, call.Args[1])
 	return r
 }
 


### PR DESCRIPTION
With the addition of the context argument to client methods, the indices for arguments we used in parsing were all off by one.




Note: In renterd at least, there are places where the Prometheus types helpers are used or there is other custom encoding.  It will be necessary to use `jc.Custom` to tell the analyzer your intent in those places, otherwise you will get "GET routes should write a response object" and "Client references route not defined by server" for that route.

[Example fix](https://github.com/SiaFoundation/renterd/blob/77006af3f5d04852c66de657e1c2f005b32ed12e/bus/routes.go#L215):
```
func (b *Bus) consensusStateHandler(jc jape.Context) {
    cs, err := b.consensusState(jc.Request.Context())
    if jc.Check("failed to fetch consensus state", err) != nil {
        return
    }

    api.WriteResponse(jc, cs)
    jc.Custom("GET", api.ConsensusState{})
}
```
