### PR TITLE
limit default request body size

### DIFF
--- a/.changeset/add_decodelimit_to_limit_the_size_of_the_incoming_request_body.md
+++ b/.changeset/add_decodelimit_to_limit_the_size_of_the_incoming_request_body.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Limit the default size of incoming request bodies to 10MB
+
+# Add `Context.DecodeLimit` to override the size limit

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // A Client provides methods for interacting with an API server.
@@ -38,7 +39,7 @@ func (c *Client) req(ctx context.Context, method string, route string, data, res
 	defer r.Body.Close()
 	if !(200 <= r.StatusCode && r.StatusCode < 300) {
 		err, _ := io.ReadAll(r.Body)
-		return errors.New(string(err))
+		return errors.New(strings.TrimSpace(string(err)))
 	}
 	if resp == nil {
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 require (
 	github.com/julienschmidt/httprouter v1.3.0
 	golang.org/x/tools v0.32.0
+	lukechampine.com/frand v1.5.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
 golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
 golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
+lukechampine.com/frand v1.5.1 h1:fg0eRtdmGFIxhP5zQJzM1lFDbD6CUfu/f+7WgAZd5/w=
+lukechampine.com/frand v1.5.1/go.mod h1:4VstaWc2plN4Mjr10chUD46RAVGWhpkZ5Nja8+Azp0Q=

--- a/server.go
+++ b/server.go
@@ -59,10 +59,10 @@ func (c Context) Encode(v any) {
 	}
 }
 
-// DecodeLimit decodes the JSON of the request body into v. If v is larger than `max`, decoding will fail. If decoding fails, Decode
+// DecodeLimit decodes the JSON of the request body into v. If v is larger than `n`, decoding will fail. If decoding fails, Decode
 // writes an error to the response body and returns it.
-func (c Context) DecodeLimit(v any, max int64) error {
-	if err := json.NewDecoder(io.LimitReader(c.Request.Body, max)).Decode(v); err != nil {
+func (c Context) DecodeLimit(v any, n int64) error {
+	if err := json.NewDecoder(io.LimitReader(c.Request.Body, n)).Decode(v); err != nil {
 		return c.Error(fmt.Errorf("couldn't decode request type (%T): %w", v, err), http.StatusBadRequest)
 	}
 	return nil

--- a/server_test.go
+++ b/server_test.go
@@ -73,5 +73,4 @@ func TestRequestTooLarge(t *testing.T) {
 	} else if r.Bar != hex.EncodeToString(content) {
 		t.Fatalf(`expected %q, got %q`, hex.EncodeToString(content), r.Bar)
 	}
-
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,77 @@
+package jape
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+
+	"lukechampine.com/frand"
+)
+
+func TestRequestTooLarge(t *testing.T) {
+	type (
+		req struct {
+			Foo []byte `json:"foo"`
+		}
+
+		resp struct {
+			Bar string `json:"bar"`
+		}
+	)
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer l.Close()
+
+	s := &http.Server{
+		Handler: Mux(map[string]Handler{
+			"POST /foo": func(c Context) {
+				var r req
+				if c.DecodeLimit(&r, 1000) != nil {
+					return
+				}
+
+				resp := resp{
+					Bar: hex.EncodeToString(r.Foo),
+				}
+				c.Encode(resp)
+			},
+		}),
+	}
+	defer s.Close()
+
+	go func() {
+		if err := s.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	c := Client{
+		BaseURL:  "http://" + l.Addr().String(),
+		Password: "",
+	}
+
+	var r resp
+	err = c.req(context.Background(), http.MethodPost, "/foo", req{
+		Foo: frand.Bytes(1001),
+	}, &r)
+	if err.Error() != "request body too large" {
+		t.Fatalf(`expected "request body too large", got %q`, err)
+	}
+
+	content := frand.Bytes(64)
+	err = c.req(context.Background(), http.MethodPost, "/foo", req{
+		Foo: content,
+	}, &r)
+	if err != nil {
+		t.Fatalf(`unexpected error: %v`, err)
+	} else if r.Bar != hex.EncodeToString(content) {
+		t.Fatalf(`expected %q, got %q`, hex.EncodeToString(content), r.Bar)
+	}
+
+}


### PR DESCRIPTION
Limits the default request body size to 10MB and adds `DecodeLimit` as an optional override